### PR TITLE
Change broker to bootstrapServers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Changed
 
 - Target `Microsoft.NETFramework.ReferenceAssemblies` v `1.0.0`
+- *BREAKING*: Replace `broker : Uri` with `bootstrapServers : string` (use `(Config.validateBrokerUri broker)` for backcompat if required)
+
 
 ### Removed
 ### Fixed

--- a/tests/FsKafka.Integration/Integration.fs
+++ b/tests/FsKafka.Integration/Integration.fs
@@ -37,7 +37,7 @@ module Helpers =
     let getTestBroker() = 
         match Environment.GetEnvironmentVariable "TEST_KAFKA_BROKER" with
         | x when String.IsNullOrEmpty x -> invalidOp "missing environment variable 'TEST_KAFKA_BROKER'"
-        | x -> Uri x
+        | x -> Uri x |> Config.validateBrokerUri
 
     let newId () = let g = System.Guid.NewGuid() in g.ToString("N")
 
@@ -61,7 +61,7 @@ module Helpers =
     type ConsumedTestMessage = { consumerId : int ; message : ConsumeResult<string,string> ; payload : TestMessage }
     type ConsumerCallback = BatchedConsumer -> ConsumedTestMessage [] -> Async<unit>
 
-    let runProducers log (broker : Uri) (topic : string) (numProducers : int) (messagesPerProducer : int) = async {
+    let runProducers log broker (topic : string) (numProducers : int) (messagesPerProducer : int) = async {
         let runProducer (producerId : int) = async {
             let cfg = KafkaProducerConfig.Create("panther", broker, Acks.Leader)
             use producer = BatchedProducer.CreateWithConfigOverrides(log, cfg, topic, maxInFlight = 10000)


### PR DESCRIPTION
The `broker : Uri` arg in the Producer and Consumer config wrappers currently constrain the `bootstrapServers` passed to a single entry.
This obscures a core function of an idiomatic Kafka Client for a debatable reason

There is currently a workaround (which I didnt realize in advance of implementing this 😊) - supply a dummy value for `broker` and then stuff in a custom `bootstrapServers` value via `custom`

I may consider deferring the merging of this until 2.0.0 depending on what folks think

If anyone has any insights like e.g. telling me that in practice `bootstrapServers` are never usefully >1 therefore this makes no sense, let me know too!

This will also flow through to the parallel implementation contained in https://github.com/jet/propulsion/tree/master/src/Propulsion.Kafka0