### PR TITLE
Add ProduceAsync overloads for headers, raw messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- Added optional `headers` param: `KafkaProducer.ProduceAsync(key, value, ?headers)`
+- Exposed lower level `KafkaProducer.ProduceAsync(Message<string,string>)`
+
 ### Changed
 ### Removed
 ### Fixed


### PR DESCRIPTION
Derived from code/requirements by @luo4neck @eglyph
- Provides ability to optionally add headers to messages in `ProduceAsync`
- Exposes a `ProduceAsync` overload
- Threads through cancellation