### PR TITLE
Add/Change KafkaConsumer/ProducerConfig autoOffsetReset, requestTimeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 
 - `FsKafka0`: (Moved from [Propulsion.Kafka0](https://github.com/jet/propulsion/tree/ddbcf41072627b26c39ecc915cb747a71ce2a91d/src/Propulsion.Kafka0)) - Implementation of same API as FsKafka based on `Confluent.Kafka` v `0.11.3` [#51](https://github.com/jet/FsKafka/pull/51)
-- `KafkaMonitor` based on [Burrow](https://github.com/linkedin/Burrow) (Moved from [Propulsion.Kafka](https://github.com/jet/propulsion/tree/ddbcf41072627b26c39ecc915cb747a71ce2a91d/src/Propulsion.Kafka) [jet/Propulsion #51](https://github.com/jet/FsKafka/pull/51) [#12](https://github.com/jet/propulsion/pull/12) :pray: [@jgardella](https://github.com/jgardella)
+- `KafkaMonitor` based on [Burrow](https://github.com/linkedin/Burrow) (Moved from [Propulsion.Kafka](https://github.com/jet/propulsion/tree/ddbcf41072627b26c39ecc915cb747a71ce2a91d/src/Propulsion.Kafka) [jet/Propulsion #12](https://github.com/jet/propulsion/pull/12) [#51](https://github.com/jet/FsKafka/pull/51) :pray: [@jgardella](https://github.com/jgardella)
 - `KafkaProducerConfig.Create`: `requestTimeoutMs` [#52](https://github.com/jet/FsKafka/pull/52)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 - `FsKafka0`: (Moved from [Propulsion.Kafka0](https://github.com/jet/propulsion/tree/ddbcf41072627b26c39ecc915cb747a71ce2a91d/src/Propulsion.Kafka0)) - Implementation of same API as FsKafka based on `Confluent.Kafka` v `0.11.3` [#51](https://github.com/jet/FsKafka/pull/51)
 - `KafkaMonitor` based on [Burrow](https://github.com/linkedin/Burrow) (Moved from [Propulsion.Kafka](https://github.com/jet/propulsion/tree/ddbcf41072627b26c39ecc915cb747a71ce2a91d/src/Propulsion.Kafka) [jet/Propulsion #51](https://github.com/jet/FsKafka/pull/51) [#12](https://github.com/jet/propulsion/pull/12) :pray: [@jgardella](https://github.com/jgardella)
+- `KafkaProducerConfig.Create`: `requestTimeoutMs` [#52](https://github.com/jet/FsKafka/pull/52)
 
 ### Changed
 
@@ -27,7 +28,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Removed
 
-- Removed `Config.validateBrokerUri` [#51](https://github.com/jet/FsKafka/pull/51)
+- `Config.validateBrokerUri` [#51](https://github.com/jet/FsKafka/pull/51)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,12 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 
 - `FsKafka0`: (Moved from [Propulsion.Kafka0](https://github.com/jet/propulsion/tree/ddbcf41072627b26c39ecc915cb747a71ce2a91d/src/Propulsion.Kafka0)) - Implementation of same API as FsKafka based on `Confluent.Kafka` v `0.11.3` [#51](https://github.com/jet/FsKafka/pull/51)
-- `KafkaMonitor` based on [Burrow](https://github.com/linkedin/Burrow) (Moved from [Propulsion.Kafka](https://github.com/jet/propulsion/tree/ddbcf41072627b26c39ecc915cb747a71ce2a91d/src/Propulsion.Kafka)) [#51](https://github.com/jet/FsKafka/pull/51) [#12](https://github.com/jet/propulsion/pull/12) :pray: [@jgardella](https://github.com/jgardella)
+- `KafkaMonitor` based on [Burrow](https://github.com/linkedin/Burrow) (Moved from [Propulsion.Kafka](https://github.com/jet/propulsion/tree/ddbcf41072627b26c39ecc915cb747a71ce2a91d/src/Propulsion.Kafka) [jet/Propulsion #51](https://github.com/jet/FsKafka/pull/51) [#12](https://github.com/jet/propulsion/pull/12) :pray: [@jgardella](https://github.com/jgardella)
 
 ### Changed
 
 - Target `Confluent.Kafka` / `librdkafka.redist` v `[1.4.2] [#53](https://github.com/jet/FsKafka/pull/53)
+- `KafkaConsumerConfig.Create`: Made `autoOffsetReset` argument mandatory [#52](https://github.com/jet/FsKafka/pull/52)
 
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 - `KafkaConsumerConfig.Create`: Made `autoOffsetReset` argument mandatory [#52](https://github.com/jet/FsKafka/pull/52)
 
 ### Removed
+
+- Removed `Config.validateBrokerUri` [#51](https://github.com/jet/FsKafka/pull/51)
+
 ### Fixed
 
 <a name="1.4.1"></a>

--- a/src/FsKafka/FsKafka.fs
+++ b/src/FsKafka/FsKafka.fs
@@ -37,6 +37,8 @@ type KafkaProducerConfig private (inner, bootstrapServers : string) =
             ?retryBackoff,
             /// Statistics Interval. Default: no stats.
             ?statisticsInterval,
+            /// Ack timeout (assuming Acks != Acks.0). Confluent.Kafka default: 5s.
+            ?requestTimeout,
             /// Confluent.Kafka default: false. Defaults to true.
             ?socketKeepAlive,
             /// Partition algorithm. Default: `ConsistentRandom`.
@@ -60,6 +62,7 @@ type KafkaProducerConfig private (inner, bootstrapServers : string) =
         linger |> Option.iter<TimeSpan> (fun x -> c.LingerMs <- Nullable x.TotalMilliseconds) // default 0
         partitioner |> Option.iter (fun x -> c.Partitioner <- Nullable x)
         compression |> Option.iter (fun x -> c.CompressionType <- Nullable x)
+        requestTimeout |> Option.iter<TimeSpan> (fun x -> c.RequestTimeoutMs <- Nullable (int x.TotalMilliseconds))
         statisticsInterval |> Option.iter<TimeSpan> (fun x -> c.StatisticsIntervalMs <- Nullable (int x.TotalMilliseconds))
         custom |> Option.iter (fun xs -> for KeyValue (k,v) in xs do c.Set(k,v))
         customize |> Option.iter (fun f -> f c)

--- a/src/FsKafka/FsKafka.fs
+++ b/src/FsKafka/FsKafka.fs
@@ -204,8 +204,8 @@ type KafkaConsumerConfig = private { inner: ConsumerConfig; topics: string list;
             clientId : string, bootstrapServers : string, topics,
             /// Consumer group identifier.
             groupId,
-            /// Specifies handling when Consumer Group does not yet have an offset recorded. Confluent.Kafka default: start from Latest. Default: start from Earliest.
-            ?autoOffsetReset,
+            /// Specifies handling when Consumer Group does not yet have an offset recorded. Confluent.Kafka default: start from Latest.
+            autoOffsetReset,
             /// Default 100kB. Confluent.Kafka default: 500MB
             ?fetchMaxBytes,
             /// Default: use `fetchMaxBytes` value (or its default, 100kB). Confluent.Kafka default: 1mB
@@ -240,7 +240,7 @@ type KafkaConsumerConfig = private { inner: ConsumerConfig; topics: string list;
             let customPropsDictionary = match config with Some x -> x | None -> Dictionary<string,string>() :> IDictionary<string,string>
             ConsumerConfig(customPropsDictionary, // CK 1.2 and later has a default ctor and an IDictionary<string,string> overload
                 ClientId=clientId, BootstrapServers=bootstrapServers, GroupId=groupId,
-                AutoOffsetReset = Nullable (defaultArg autoOffsetReset AutoOffsetReset.Earliest), // default: latest
+                AutoOffsetReset = Nullable autoOffsetReset, // default: latest
                 FetchMaxBytes = Nullable fetchMaxBytes, // default: 524_288_000
                 MessageMaxBytes = Nullable (defaultArg messageMaxBytes fetchMaxBytes), // default 1_000_000
                 EnableAutoCommit = Nullable true, // at AutoCommitIntervalMs interval, write value supplied by StoreOffset call

--- a/src/FsKafka0/ConfluentKafkaShims.fs
+++ b/src/FsKafka0/ConfluentKafkaShims.fs
@@ -52,6 +52,7 @@ module Config =
         let linger              = mkKey "linger.ms" id<int>
         let messageSendRetries  = mkKey "message.send.max.retries" id<int>
         let partitioner         = mkKey "partitioner" (function Partitioner.Random -> "random" | Partitioner.Consistent -> "consistent" | Partitioner.ConsistentRandom -> "consistent_random")
+        let requestTimeoutMs    = mkKey "request.timeout.ms" id<int>
 
      /// Config keys applying to Consumers
     module Consumer =
@@ -86,6 +87,7 @@ type ProducerConfig() =
     member val LingerMs = Nullable() with get, set
     member val Partitioner = Nullable() with get, set
     member val CompressionType = Nullable() with get, set
+    member val RequestTimeoutMs = Nullable() with get, set
     member val StatisticsIntervalMs = Nullable() with get, set
 
     member __.Render() : KeyValuePair<string,obj>[] =
@@ -100,6 +102,7 @@ type ProducerConfig() =
             match __.LingerMs               with Null -> () | HasValue v -> yield Config.Producer.linger ==> v
             match __.Partitioner            with Null -> () | HasValue v -> yield Config.Producer.partitioner ==> v
             match __.CompressionType        with Null -> () | HasValue v -> yield Config.Producer.compression ==> v
+            match __.RequestTimeoutMs       with Null -> () | HasValue v -> yield Config.Producer.requestTimeoutMs ==> v
             match __.StatisticsIntervalMs   with Null -> () | HasValue v -> yield Config.statisticsInterval ==> v
             yield! values |]
 

--- a/src/FsKafka0/FsKafka.fs
+++ b/src/FsKafka0/FsKafka.fs
@@ -35,6 +35,8 @@ type KafkaProducerConfig private (inner, bootstrapServers : string) =
             ?retries,
             /// Backoff interval. Confluent.Kafka default: 100ms. Default: 1s.
             ?retryBackoff,
+            /// Ack timeout (assuming Acks != Acks.0). Confluent.Kafka default: 5s.
+            ?requestTimeout,
             /// Statistics Interval. Default: no stats.
             ?statisticsInterval,
             /// Confluent.Kafka default: false. Defaults to true.
@@ -60,6 +62,7 @@ type KafkaProducerConfig private (inner, bootstrapServers : string) =
         linger |> Option.iter<TimeSpan> (fun x -> c.LingerMs <- Nullable (int x.TotalMilliseconds)) // default 0
         partitioner |> Option.iter (fun x -> c.Partitioner <- Nullable x)
         compression |> Option.iter (fun x -> c.CompressionType <- Nullable x)
+        requestTimeout |> Option.iter<TimeSpan> (fun x -> c.RequestTimeoutMs <- Nullable (int x.TotalMilliseconds))
         statisticsInterval |> Option.iter<TimeSpan> (fun x -> c.StatisticsIntervalMs <- Nullable (int x.TotalMilliseconds))
         custom |> Option.iter (fun xs -> for KeyValue (k,v) in xs do c.Set(k,v))
         customize |> Option.iter (fun f -> f c)

--- a/src/FsKafka0/FsKafka.fs
+++ b/src/FsKafka0/FsKafka.fs
@@ -199,8 +199,8 @@ type KafkaConsumerConfig = private { inner: ConsumerConfig; topics: string list;
             clientId : string, bootstrapServers : string, topics,
             /// Consumer group identifier.
             groupId,
-            /// Specifies handling when Consumer Group does not yet have an offset recorded. Confluent.Kafka default: start from Latest. Default: start from Earliest.
-            ?autoOffsetReset,
+            /// Specifies handling when Consumer Group does not yet have an offset recorded. Confluent.Kafka default: start from Latest.
+            autoOffsetReset,
             /// Default 100kB. Confluent.Kafka default: 500MB
             ?fetchMaxBytes,
             /// Minimum number of bytes to wait for (subject to timeout with default of 100ms). Default 1B.
@@ -232,7 +232,7 @@ type KafkaConsumerConfig = private { inner: ConsumerConfig; topics: string list;
         let c =
             ConsumerConfig(
                 ClientId = clientId, BootstrapServers = bootstrapServers, GroupId = groupId,
-                AutoOffsetReset = Nullable (defaultArg autoOffsetReset AutoOffsetReset.Earliest), // default: latest
+                AutoOffsetReset = Nullable autoOffsetReset, // default: latest
                 FetchMaxBytes = Nullable fetchMaxBytes, // default: 524_288_000
                 EnableAutoCommit = Nullable true, // at AutoCommitIntervalMs interval, write value supplied by StoreOffset call
                 EnableAutoOffsetStore = Nullable false, // explicit calls to StoreOffset are the only things that effect progression in offsets

--- a/tests/FsKafka.Integration/Integration.fs
+++ b/tests/FsKafka.Integration/Integration.fs
@@ -1,5 +1,6 @@
 namespace FsKafka.Integration
 
+open Confluent.Kafka
 open FsKafka
 open Newtonsoft.Json
 open Serilog
@@ -149,7 +150,7 @@ type T1(testOutputHelper) =
         // Section: run the test
         let producers = runProducers log broker topic numProducers messagesPerProducer |> Async.Ignore
 
-        let config = KafkaConsumerConfig.Create("panther", broker, [topic], groupId, statisticsInterval=(TimeSpan.FromSeconds 5.))
+        let config = KafkaConsumerConfig.Create("panther", broker, [topic], groupId, AutoOffsetReset.Earliest, statisticsInterval=TimeSpan.FromSeconds 5.)
         let consumers = runConsumers log config numConsumers None consumerCallback
 
         let! _ = [ producers ; consumers ] |> Async.Parallel
@@ -199,7 +200,7 @@ type T2(testOutputHelper) =
 
         let! _ = runProducers log broker topic 1 10 // populate the topic with a few messages
 
-        let config = KafkaConsumerConfig.Create("panther", broker, [topic], groupId)
+        let config = KafkaConsumerConfig.Create("panther", broker, [topic], groupId, AutoOffsetReset.Earliest)
         
         let! r = Async.Catch <| runConsumers log config 1 None (fun _ _ -> raise <|IndexOutOfRangeException())
         test <@ match r with Choice2Of2 (:? IndexOutOfRangeException) -> true | x -> failwithf "%A" x @>
@@ -214,7 +215,7 @@ type T2(testOutputHelper) =
 
         let messageCount = ref 0
         let groupId1 = newId()
-        let config = KafkaConsumerConfig.Create("panther", broker, [topic], groupId1)
+        let config = KafkaConsumerConfig.Create("panther", broker, [topic], groupId1, AutoOffsetReset.Earliest)
         do! runConsumers log config 1 None 
                 (fun c b -> async { if Interlocked.Add(messageCount, b.Length) >= numMessages then c.Stop() })
 
@@ -222,7 +223,7 @@ type T2(testOutputHelper) =
 
         let messageCount = ref 0
         let groupId2 = newId()
-        let config = KafkaConsumerConfig.Create("panther", broker, [topic], groupId2)
+        let config = KafkaConsumerConfig.Create("panther", broker, [topic], groupId2, AutoOffsetReset.Earliest)
         do! runConsumers log config 1 None
                 (fun c b -> async { if Interlocked.Add(messageCount, b.Length) >= numMessages then c.Stop() })
 
@@ -233,7 +234,7 @@ type T2(testOutputHelper) =
         let numMessages = 10
         let topic = newId() // dev kafka topics are created and truncated automatically
         let groupId = newId()
-        let config = KafkaConsumerConfig.Create("panther", broker, [topic], groupId)
+        let config = KafkaConsumerConfig.Create("panther", broker, [topic], groupId, AutoOffsetReset.Earliest)
 
         let! _ = runProducers log broker topic 1 numMessages // populate the topic with a few messages
 
@@ -263,7 +264,7 @@ type T3(testOutputHelper) =
         let numMessages = 10
         let topic = newId() // dev kafka topics are created and truncated automatically
         let groupId = newId()
-        let config = KafkaConsumerConfig.Create("panther", broker, [topic], groupId)
+        let config = KafkaConsumerConfig.Create("panther", broker, [topic], groupId, AutoOffsetReset.Earliest)
 
         let! _ = runProducers log broker topic 1 numMessages // populate the topic with a few messages
 
@@ -298,7 +299,7 @@ type T3(testOutputHelper) =
         let maxBatchSize = 5
         let topic = newId() // dev kafka topics are created and truncated automatically
         let groupId = newId()
-        let config = KafkaConsumerConfig.Create("panther", broker, [topic], groupId, maxBatchSize = maxBatchSize)
+        let config = KafkaConsumerConfig.Create("panther", broker, [topic], groupId, AutoOffsetReset.Earliest, maxBatchSize = maxBatchSize)
 
         // Produce messages in the topic
         do! runProducers log broker topic 1 numMessages |> Async.Ignore


### PR DESCRIPTION
- The longstanding default for autoOffsetReset for FsKafka has always been `earliest`, which is a safe default, but is not the Confluent.Kafka one (which is Latest).
  This PR removes that defaulting in order to force a deliberate choice on the part of the user.
- Exposes `requestTimeout` on `KafkaProducerConfig.Create`

cc @wantastic84 @swrhim