### PR TITLE
Logging updates for handling consumer errors

### DIFF
--- a/src/FsKafka/FsKafka.fs
+++ b/src/FsKafka/FsKafka.fs
@@ -304,7 +304,11 @@ type ConsumerBuilder =
     static member WithLogging(log : ILogger, config : ConsumerConfig, ?onRevoke) =
         ConsumerBuilder<_,_>(config)
             .SetLogHandler(fun _c m -> log.Information("Consuming... {message} level={level} name={name} facility={facility}", m.Message, m.Level, m.Name, m.Facility))
-            .SetErrorHandler(fun _c e -> log.Error("Consuming... Error reason={reason} code={code} isBrokerError={isBrokerError}", e.Reason, e.Code, e.IsBrokerError))
+            .SetErrorHandler(fun _c e ->
+                if e.IsFatal then
+                    log.Error("Consuming... Error reason={reason} code={code} isBrokerError={isBrokerError}", e.Reason, e.Code, e.IsBrokerError)
+                else
+                    log.Warning("Consuming... Warning reason={reason} code={code} isBrokerError={isBrokerError}", e.Reason, e.Code, e.IsBrokerError))
             .SetStatisticsHandler(fun c json -> 
                 // Stats format: https://github.com/edenhill/librdkafka/blob/master/STATISTICS.md
                 let stats = JToken.Parse json

--- a/src/FsKafka0/FsKafka.fs
+++ b/src/FsKafka0/FsKafka.fs
@@ -330,7 +330,7 @@ type ConsumerBuilder =
                     log.Information("Consuming... Stats {topic:l} totalLag {totalLag} {@stats}", topic, totalLag, metrics))
         let d8 = c.OnConsumeError.Subscribe (fun msg ->
              if msg.Error.HasError then
-                log.Error ("Error reason={reason} topic={topic} partition={partition} offset={offset}", msg.Error.Reason, msg.Topic, msg.Partition, msg.Offset))
+                log.Error ("Consuming... Error reason={reason} topic={topic} partition={partition} offset={offset}", msg.Error.Reason, msg.Topic, msg.Partition, msg.Offset))
         fun () -> for d in [d1;d2;d3;d4;d5;d6;d7;d8] do d.Dispose()
     static member WithLogging(log : ILogger, config : ConsumerConfig, ?onRevoke) =
         let consumer = new Consumer<_,_>(config.Render(), mkDeserializer(), mkDeserializer())


### PR DESCRIPTION
- FsKafka: Added filter to treat Fatal errors and warnings distinctly,
- FsKafka0: Added an observer `OnConsumeError`