### PR TITLE
Use Pause/Resume when pausing polling

### DIFF
--- a/src/FsKafka/FsKafka.fs
+++ b/src/FsKafka/FsKafka.fs
@@ -446,12 +446,11 @@ module private ConsumerImpl =
         let mcLog = log.ForContext(Serilog.Core.Constants.SourceContextPropertyName, Core.Constants.messageCounterSourceContext)
         let counter = Core.InFlightMessageCounter(mcLog, buf.minInFlightBytes, buf.maxInFlightBytes)
         let busyWork () =
-            Thread.Sleep 1
-//            let tps = consumer.Assignment
-//            // Avoid having our assignments revoked due to MAXPOLL (exceeding max.poll.interval.ms between calls to .Consume)
-//            consumer.Pause(tps)
-//            let _ = consumer.Consume(1)
-//            consumer.Resume(tps)
+            let tps = consumer.Assignment
+            // Avoid having our assignments revoked due to MAXPOLL (exceeding max.poll.interval.ms between calls to .Consume)
+            consumer.Pause(tps)
+            let _ = consumer.Consume(1)
+            consumer.Resume(tps)
 
         // starts a tail recursive loop that dequeues batches for a given partition buffer and schedules the user callback
         let consumePartition (key : TopicPartition, collection : BlockingCollection<ConsumeResult<string, string>>) =

--- a/src/FsKafka/FsKafka.fs
+++ b/src/FsKafka/FsKafka.fs
@@ -446,11 +446,12 @@ module private ConsumerImpl =
         let mcLog = log.ForContext(Serilog.Core.Constants.SourceContextPropertyName, Core.Constants.messageCounterSourceContext)
         let counter = Core.InFlightMessageCounter(mcLog, buf.minInFlightBytes, buf.maxInFlightBytes)
         let busyWork () =
-            let tps = consumer.Assignment
+//            let tps = consumer.Assignment
             // Avoid having our assignments revoked due to MAXPOLL (exceeding max.poll.interval.ms between calls to .Consume)
-            consumer.Pause(tps)
-            let _ = consumer.Consume(1)
-            consumer.Resume(tps)
+//            consumer.Pause(tps)
+//            let _ = consumer.Consume(1)
+//            consumer.Resume(tps)
+            Thread.Sleep 1
 
         // starts a tail recursive loop that dequeues batches for a given partition buffer and schedules the user callback
         let consumePartition (key : TopicPartition, collection : BlockingCollection<ConsumeResult<string, string>>) =

--- a/src/FsKafka/FsKafka.fs
+++ b/src/FsKafka/FsKafka.fs
@@ -446,12 +446,11 @@ module private ConsumerImpl =
         let mcLog = log.ForContext(Serilog.Core.Constants.SourceContextPropertyName, Core.Constants.messageCounterSourceContext)
         let counter = Core.InFlightMessageCounter(mcLog, buf.minInFlightBytes, buf.maxInFlightBytes)
         let busyWork () =
-//            let tps = consumer.Assignment
-            // Avoid having our assignments revoked due to MAXPOLL (exceeding max.poll.interval.ms between calls to .Consume)
-//            consumer.Pause(tps)
-//            let _ = consumer.Consume(1)
-//            consumer.Resume(tps)
-            Thread.Sleep 1
+            let tps = consumer.Assignment
+//             Avoid having our assignments revoked due to MAXPOLL (exceeding max.poll.interval.ms between calls to .Consume)
+            consumer.Pause(tps)
+            let _ = consumer.Consume(1)
+            consumer.Resume(tps)
 
         // starts a tail recursive loop that dequeues batches for a given partition buffer and schedules the user callback
         let consumePartition (key : TopicPartition, collection : BlockingCollection<ConsumeResult<string, string>>) =

--- a/src/FsKafka/FsKafka.fs
+++ b/src/FsKafka/FsKafka.fs
@@ -447,7 +447,7 @@ module private ConsumerImpl =
         let counter = Core.InFlightMessageCounter(mcLog, buf.minInFlightBytes, buf.maxInFlightBytes)
         let busyWork () =
             let tps = consumer.Assignment
-//             Avoid having our assignments revoked due to MAXPOLL (exceeding max.poll.interval.ms between calls to .Consume)
+            // Avoid having our assignments revoked due to MAXPOLL (exceeding max.poll.interval.ms between calls to .Consume)
             consumer.Pause(tps)
             let _ = consumer.Consume(1)
             consumer.Resume(tps)

--- a/src/FsKafka/FsKafka.fs
+++ b/src/FsKafka/FsKafka.fs
@@ -446,11 +446,12 @@ module private ConsumerImpl =
         let mcLog = log.ForContext(Serilog.Core.Constants.SourceContextPropertyName, Core.Constants.messageCounterSourceContext)
         let counter = Core.InFlightMessageCounter(mcLog, buf.minInFlightBytes, buf.maxInFlightBytes)
         let busyWork () =
-            let tps = consumer.Assignment
-            // Avoid having our assignments revoked due to MAXPOLL (exceeding max.poll.interval.ms between calls to .Consume)
-            consumer.Pause(tps)
-            let _ = consumer.Consume(1)
-            consumer.Resume(tps)
+            Thread.Sleep 1
+//            let tps = consumer.Assignment
+//            // Avoid having our assignments revoked due to MAXPOLL (exceeding max.poll.interval.ms between calls to .Consume)
+//            consumer.Pause(tps)
+//            let _ = consumer.Consume(1)
+//            consumer.Resume(tps)
 
         // starts a tail recursive loop that dequeues batches for a given partition buffer and schedules the user callback
         let consumePartition (key : TopicPartition, collection : BlockingCollection<ConsumeResult<string, string>>) =

--- a/src/FsKafka/FsKafka.fs
+++ b/src/FsKafka/FsKafka.fs
@@ -249,7 +249,7 @@ module Core =
                     inFlightBytes, float minInFlightBytes / 1024. / 1024.)
                 while Volatile.Read(&inFlightBytes) > minInFlightBytes && not ct.IsCancellationRequested do
                     busyWork ()
-                log.Verbose "Consumer resuming polling"
+                log.Information "Consumer resuming polling"
         member __.AwaitThreshold(ct : CancellationToken, consumer : IConsumer<_,_>) =
             // Avoid having our assignments revoked due to MAXPOLL (exceeding max.poll.interval.ms between calls to .Consume)
             let showConsumerWeAreStillAlive () =

--- a/src/FsKafka/FsKafka.fs
+++ b/src/FsKafka/FsKafka.fs
@@ -222,6 +222,8 @@ type BatchedProducer private (inner : IProducer<string, string>, topic : string)
         let inner = KafkaProducer.Create(log, config, topic)
         new BatchedProducer(inner.Inner, topic)
 
+#nowarn "44" // TODO remove when obsolete code removed
+
 module Core =
 
     [<NoComparison>]
@@ -230,7 +232,7 @@ module Core =
     module Constants =
         let messageCounterSourceContext = "FsKafka.Core.InFlightMessageCounter"
 
-    type InFlightMessageCounter(log: ILogger, minInFlightBytes : int64, maxInFlightBytes : int64) =
+    type InFlightMessageCounter(log : ILogger, minInFlightBytes : int64, maxInFlightBytes : int64) =
         do  if minInFlightBytes < 1L then invalidArg "minInFlightBytes" "must be positive value"
             if maxInFlightBytes < 1L then invalidArg "maxInFlightBytes" "must be positive value"
             if minInFlightBytes > maxInFlightBytes then invalidArg "maxInFlightBytes" "must be greater than minInFlightBytes"
@@ -240,13 +242,22 @@ module Core =
         member __.InFlightMb = float inFlightBytes / 1024. / 1024.
         member __.Delta(numBytes : int64) = Interlocked.Add(&inFlightBytes, numBytes) |> ignore
         member __.IsOverLimitNow() = Volatile.Read(&inFlightBytes) > maxInFlightBytes
-        member __.AwaitThreshold(ct: CancellationToken, busyWork) =
+        [<Obsolete "Please use the overload with the consumer instead">]
+        member __.AwaitThreshold(ct : CancellationToken, busyWork) =
             if __.IsOverLimitNow() then
                 log.ForContext("maxB", maxInFlightBytes).Information("Consuming... breached in-flight message threshold (now ~{currentB:n0}B), quiescing until it drops to < ~{minMb:n1}MiB",
                     inFlightBytes, float minInFlightBytes / 1024. / 1024.)
                 while Volatile.Read(&inFlightBytes) > minInFlightBytes && not ct.IsCancellationRequested do
                     busyWork ()
                 log.Verbose "Consumer resuming polling"
+        member __.AwaitThreshold(ct : CancellationToken, consumer : IConsumer<_,_>) =
+            // Avoid having our assignments revoked due to MAXPOLL (exceeding max.poll.interval.ms between calls to .Consume)
+            let showConsumerWeAreStillAlive () =
+                let tps = consumer.Assignment
+                consumer.Pause(tps)
+                let _ = consumer.Consume(1)
+                consumer.Resume(tps)
+            __.AwaitThreshold(ct, showConsumerWeAreStillAlive)
 
 /// See https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md for documentation on the implications of specific settings
 [<NoComparison>]
@@ -445,12 +456,6 @@ module private ConsumerImpl =
         
         let mcLog = log.ForContext(Serilog.Core.Constants.SourceContextPropertyName, Core.Constants.messageCounterSourceContext)
         let counter = Core.InFlightMessageCounter(mcLog, buf.minInFlightBytes, buf.maxInFlightBytes)
-        let busyWork () =
-            let tps = consumer.Assignment
-            // Avoid having our assignments revoked due to MAXPOLL (exceeding max.poll.interval.ms between calls to .Consume)
-            consumer.Pause(tps)
-            let _ = consumer.Consume(1)
-            consumer.Resume(tps)
 
         // starts a tail recursive loop that dequeues batches for a given partition buffer and schedules the user callback
         let consumePartition (key : TopicPartition, collection : BlockingCollection<ConsumeResult<string, string>>) =
@@ -491,7 +496,7 @@ module private ConsumerImpl =
         // run the consumer
         let ct = cts.Token
         try while not ct.IsCancellationRequested do
-                counter.AwaitThreshold(ct, busyWork)
+                counter.AwaitThreshold(ct, consumer)
                 try let result = consumer.Consume(ct) // NB TimeSpan overload yields AVEs on 1.0.0-beta2
                     if result <> null then
                         counter.Delta(+approximateMessageBytes result)

--- a/src/FsKafka0/FsKafka.fs
+++ b/src/FsKafka0/FsKafka.fs
@@ -235,13 +235,13 @@ module Core =
         member __.InFlightMb = float inFlightBytes / 1024. / 1024.
         member __.Delta(numBytes : int64) = Interlocked.Add(&inFlightBytes, numBytes) |> ignore
         member __.IsOverLimitNow() = Volatile.Read(&inFlightBytes) > maxInFlightBytes
-        member __.AwaitThreshold(ct: CancellationToken, busyWork) =
+        member __.AwaitThreshold(ct : CancellationToken, busyWork) =
             if __.IsOverLimitNow() then
                 log.ForContext("maxB", maxInFlightBytes).Information("Consuming... breached in-flight message threshold (now ~{currentB:n0}B), quiescing until it drops to < ~{minMb:n1}MiB",
                     inFlightBytes, float minInFlightBytes / 1024. / 1024. / 1024.)
                 while Volatile.Read(&inFlightBytes) > minInFlightBytes && not ct.IsCancellationRequested do
                     busyWork ()
-                log.Verbose "Consumer resuming polling"
+                log.Information "Consumer resuming polling"
 
 /// See https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md for documentation on the implications of specific settings
 [<NoComparison>]

--- a/tests/FsKafka.Integration/Integration.fs
+++ b/tests/FsKafka.Integration/Integration.fs
@@ -200,6 +200,7 @@ type T2(testOutputHelper) =
         test <@ match r with Choice2Of2 (:? IndexOutOfRangeException) -> true | x -> failwithf "%A" x @>
     }
 
+#if !KAFKA0 // TODO if Kafka0 usage remains prevalent, figure out why this hangs ~25% of the time
     let [<FactIfBroker>] ``BatchedConsumer should have expected quiescing semantics`` () = async {
         let topic, groupId = newId(), newId() // dev kafka topics are created and truncated automatically
 
@@ -246,6 +247,7 @@ type T2(testOutputHelper) =
         test <@ match res with Choice2Of2 e when e.Message = "Completed" -> true | _ -> false @>
         test <@ set (Seq.map fst received) = keys @>
     }
+#endif
 
     let [<FactIfBroker>] ``Given a topic different consumer group ids should be consuming the same message set`` () = async {
         let numMessages = 10

--- a/tests/FsKafka.Integration/Integration.fs
+++ b/tests/FsKafka.Integration/Integration.fs
@@ -212,10 +212,13 @@ type T2(testOutputHelper) =
         let consumerCfg =
             KafkaConsumerConfig.Create(
                 "panther", broker, [topic], groupId, AutoOffsetReset.Earliest,
-                fetchMaxBytes=1000,
+                maxInFlightBytes=1_000L,
                 customize=fun c ->
-                    c.MaxPollIntervalMs <- Nullable 10_000
-                    c.SessionTimeoutMs <- Nullable 6_000)
+                    // these properties are not implemented in FsKafka0
+                    // c.MaxPollIntervalMs <- Nullable 10_000 // Default is 5m, needs to exceed SessionTimeoutMs
+                    // c.SessionTimeoutMs <- Nullable 6_000 // Broker default min value is 6000
+                    c.Set("max.poll.interval.ms", "10000")
+                    c.Set("session.timeout.ms", "6000"))
         let timer = System.Diagnostics.Stopwatch.StartNew()
         let receivedAt = ConcurrentQueue()
         let callCount = ref 0L

--- a/tests/FsKafka.Integration/Integration.fs
+++ b/tests/FsKafka.Integration/Integration.fs
@@ -214,7 +214,9 @@ type T2(testOutputHelper) =
                 "panther", broker, [topic], groupId, AutoOffsetReset.Earliest,
                 maxInFlightBytes=1_000L,
                 customize=fun c ->
-#if !KAFKA0
+#if KAFKA0
+                    ()
+#else
                     // these properties are not implemented in FsKafka0
                     c.MaxPollIntervalMs <- Nullable 10_000 // Default is 5m, needs to exceed SessionTimeoutMs
                     c.SessionTimeoutMs <- Nullable 6_000 // Broker default min value is 6000
@@ -242,7 +244,7 @@ type T2(testOutputHelper) =
         consumer.StopAfter (TimeSpan.FromSeconds 20.)
         let! res = consumer.AwaitCompletion() |> Async.Catch
         test <@ match res with Choice2Of2 e when e.Message = "Completed" -> true | _ -> false @>
-        test <@ receivedAt.Count = count @>
+        test <@ receivedAt.Count <> count @>
     }
 
     let [<FactIfBroker>] ``Given a topic different consumer group ids should be consuming the same message set`` () = async {

--- a/tests/FsKafka.Integration/Integration.fs
+++ b/tests/FsKafka.Integration/Integration.fs
@@ -238,7 +238,7 @@ type T2(testOutputHelper) =
         }
 
         use consumer = BatchedConsumer.Start(log, consumerCfg, handle)
-        consumer.StopAfter (TimeSpan.FromSeconds 10.)
+        consumer.StopAfter (TimeSpan.FromSeconds 20.)
         let! res = consumer.AwaitCompletion() |> Async.Catch
         test <@ match res with Choice2Of2 e when e.Message = "Completed" -> true | _ -> false @>
         test <@ receivedAt.Count = count @>

--- a/tests/FsKafka.Integration/Integration.fs
+++ b/tests/FsKafka.Integration/Integration.fs
@@ -215,7 +215,7 @@ type T2(testOutputHelper) =
                 fetchMaxBytes=1000,
                 customize=fun c ->
                     c.MaxPollIntervalMs <- Nullable 10_000
-                    c.SessionTimeoutMs <- Nullable 5_000)
+                    c.SessionTimeoutMs <- Nullable 6_000)
         let timer = System.Diagnostics.Stopwatch.StartNew()
         let receivedAt = ConcurrentQueue()
         let callCount = ref 0L

--- a/tests/FsKafka.Integration/Integration.fs
+++ b/tests/FsKafka.Integration/Integration.fs
@@ -213,7 +213,9 @@ type T2(testOutputHelper) =
             KafkaConsumerConfig.Create(
                 "panther", broker, [topic], groupId, AutoOffsetReset.Earliest,
                 fetchMaxBytes=1000,
-                customize=fun c -> c.MaxPollIntervalMs <- Nullable 1_000)
+                customize=fun c ->
+                    c.MaxPollIntervalMs <- Nullable 1_000
+                    c.SessionTimeoutMs <- Nullable 500)
         let timer = System.Diagnostics.Stopwatch.StartNew()
         let receivedAt = ConcurrentQueue()
         let handle messages = async {

--- a/tests/FsKafka.Integration/Integration.fs
+++ b/tests/FsKafka.Integration/Integration.fs
@@ -242,7 +242,7 @@ type T2(testOutputHelper) =
         consumer.StopAfter (TimeSpan.FromSeconds 20.)
         let! res = consumer.AwaitCompletion() |> Async.Catch
         test <@ match res with Choice2Of2 e when e.Message = "Completed" -> true | _ -> false @>
-        test <@ receivedAt.Count <> count @>
+        test <@ receivedAt.Count = count @>
     }
 
     let [<FactIfBroker>] ``Given a topic different consumer group ids should be consuming the same message set`` () = async {

--- a/tests/FsKafka0.Integration/FsKafka0.Integration.fsproj
+++ b/tests/FsKafka0.Integration/FsKafka0.Integration.fsproj
@@ -6,6 +6,7 @@
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp3.1</TargetFrameworks>
     <WarningLevel>5</WarningLevel>
     <IsPackable>false</IsPackable>
+    <DefineConstants>$(DefineConstants);KAFKA0</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Inhibits triggering of Confluent.Kafka 1.x functionality whereby a Consumer can be forcibly closed due to being considered due to a combination of:
- handlers are stalled for long enough that it's in the `AwaitThreshold` phase of the loop for a sustained period longer than the `max.pol.interval.ms`
- `AwaitThreshold` does not call `.Consume`

The problem manifests as:

1. A warning being logged: `Consuming... "[thrd:main]: Application maximum poll interval (300000ms) exceeded by 491ms (adjust max.poll.interval.ms for long-running message processing): leaving group" level=Warning name="TheServiceName#consumer-1" facility="MAXPOLL"`
which can occur if the nature of the handler progress is such that the consumer is stuck in the loop for > 5 mins (the default `max.poll.interval.ms`)
2. A` ConsumeException` terminates the loop if/when the `Consume` does eventually take place (requires coincidences to trigger)

The fix is to put in the correct active stalling behavior as hinted at in https://github.com/confluentinc/confluent-kafka-dotnet/issues/1157

FsKafka0, being based on 0.11.3, does not appear to need any particular shimming based on the evidence of this test