### PR TITLE
Implement KafkaProducerConfig.allowAutoCreateTopics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- `KafkaConsumerConfig.Create`: added `allowAutoCreateTopics` argument to enable control of `allow.auto.create.topics` now that `librdkafka 1.5` changes the default [#71](https://github.com/jet/FsKafka/pull/71)
+
 ### Changed
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The repo is versioned based on [SemVer 2.0](https://semver.org/spec/v2.0.0.html) using the tiny-but-mighty [MinVer](https://github.com/adamralph/minver) from [@adamralph](https://github.com/adamralph). [See here](https://github.com/adamralph/minver#how-it-works) for more information on how it works.
 
+Please note FsKafka has (generally additive) breaking changes even in Minor and Patch releases as:
+- FsKafka binds strongly to a specific version of `Confluent.Kafka` + `librdkafka.redist`,so arbitrary replacements are already frowned on
+- a primary goal is to be terse and not vary from the underlying defaults where possible - putting in lots of Obsoleted overloads as one normally should is contrary to this goal
+
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 The `Unreleased` section name is replaced by the expected version of next release. A stable version's log contains all changes between that version and the previous stable version (can duplicate the prereleases logs).
@@ -10,7 +14,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 
-- `KafkaConsumerConfig.Create`: added `allowAutoCreateTopics` argument to enable control of `allow.auto.create.topics` now that `librdkafka 1.5` changes the default [#71](https://github.com/jet/FsKafka/pull/71)
+- BREAKING: `KafkaConsumerConfig.Create`: added `allowAutoCreateTopics` argument to enable control of `allow.auto.create.topics` now that `librdkafka 1.5` changes the default [#71](https://github.com/jet/FsKafka/pull/71)
 
 ### Changed
 ### Removed
@@ -28,11 +32,11 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Changed
 
-- Encapsulated linger/batching semantics in a `Batching` DU passed to `KafkaProducerConfig.Create` (instead of `linger` and `maxInFlight`) in lieu of having `BatchedProducer.CreateWithConfigOverrides` patch the values [#68](https://github.com/jet/FsKafka/pull/68)
+- BREAKING: Encapsulated linger/batching semantics in a `Batching` DU passed to `KafkaProducerConfig.Create` (instead of `linger` and `maxInFlight`) in lieu of having `BatchedProducer.CreateWithConfigOverrides` patch the values [#68](https://github.com/jet/FsKafka/pull/68)
 
 ### Fixed
 
-- Handle deadlock between `MaxInflightMessages` wait loop and Consumer cancellation [#61](https://github.com/jet/FsKafka/pull/61) :pray: Bilal Durrani
+- BREAKING: Handle deadlock between `MaxInflightMessages` wait loop and Consumer cancellation [#61](https://github.com/jet/FsKafka/pull/61) :pray: Bilal Durrani
 - `FsKafka0`: Aligned `Thread.Sleep` when over `maxInFlightBytes` threshold with `FsKafka` (reduced from `5` to `1` ms) [#67](https://github.com/jet/FsKafka/pull/67)
 
 <a name="1.4.4"></a>

--- a/src/FsKafka/FsKafka.fs
+++ b/src/FsKafka/FsKafka.fs
@@ -273,6 +273,8 @@ type KafkaConsumerConfig = private { inner: ConsumerConfig; topics: string list;
             ?statisticsInterval,
             /// Consumed offsets commit interval. Default 5s.
             ?autoCommitInterval,
+            /// Override default policy wrt auto-creating topics. Confluent.Kafka < 1.5 default: true; Confluent.Kafka >= 1.5 default: false
+            ?allowAutoCreateTopics,
             /// Misc configuration parameters to be passed to the underlying CK consumer. Same as constructor argument for Confluent.Kafka >=1.2.
             ?config : IDictionary<string,string>,
             /// Misc configuration parameter to be passed to the underlying CK consumer.
@@ -306,6 +308,7 @@ type KafkaConsumerConfig = private { inner: ConsumerConfig; topics: string list;
         fetchMinBytes |> Option.iter (fun x -> c.FetchMinBytes <- x) // Fetch waits for this amount of data for up to FetchWaitMaxMs (500)
         autoCommitInterval |> Option.iter<TimeSpan> (fun x -> c.AutoCommitIntervalMs <- Nullable <| int x.TotalMilliseconds)
         statisticsInterval |> Option.iter<TimeSpan> (fun x -> c.StatisticsIntervalMs <- Nullable <| int x.TotalMilliseconds)
+        allowAutoCreateTopics |> Option.iter (fun x -> c.AllowAutoCreateTopics <- Nullable x)
         custom |> Option.iter (fun xs -> for KeyValue (k,v) in xs do c.Set(k,v))
         customize |> Option.iter<ConsumerConfig -> unit> (fun f -> f c)
         {   inner = c

--- a/src/FsKafka0/ConfluentKafkaShims.fs
+++ b/src/FsKafka0/ConfluentKafkaShims.fs
@@ -58,6 +58,7 @@ module ConfigHelpers =
 
      /// Config keys applying to Consumers
     module Consumer =
+        let allowAutoCreateTopics = mkKey "allow.auto.create.topics" id<bool>
         let autoCommitInterval  = mkKey "auto.commit.interval.ms" id<int>
         let autoOffsetReset     = mkKey "auto.offset.reset" (function AutoOffsetReset.Earliest -> "earliest" | AutoOffsetReset.Latest -> "latest" | AutoOffsetReset.Error -> "error")
         let enableAutoCommit    = mkKey "enable.auto.commit" id<bool>
@@ -124,6 +125,7 @@ type ConsumerConfig() =
     member val LogConnectionClose = Nullable() with get, set
     member val FetchMinBytes = Nullable() with get, set
     member val StatisticsIntervalMs = Nullable() with get, set
+    member val AllowAutoCreateTopics = Nullable() with get, set
     member val AutoCommitIntervalMs = Nullable() with get, set
 
     member __.Render() : KeyValuePair<string,obj>[] =
@@ -136,6 +138,7 @@ type ConsumerConfig() =
             match __.EnableAutoCommit       with Null -> () | HasValue v -> yield ConfigHelpers.Consumer.enableAutoCommit ==> v
             match __.EnableAutoOffsetStore  with Null -> () | HasValue v -> yield ConfigHelpers.Consumer.enableAutoOffsetStore ==> v
             match __.FetchMinBytes          with Null -> () | HasValue v -> yield ConfigHelpers.Consumer.fetchMinBytes ==> v
+            match __.AllowAutoCreateTopics  with Null -> () | HasValue v -> yield ConfigHelpers.Consumer.allowAutoCreateTopics ==> v
             match __.AutoCommitIntervalMs   with Null -> () | HasValue v -> yield ConfigHelpers.Consumer.autoCommitInterval ==> v
             match __.StatisticsIntervalMs   with Null -> () | HasValue v -> yield ConfigHelpers.statisticsInterval ==> v
             yield! values |]

--- a/src/FsKafka0/FsKafka.fs
+++ b/src/FsKafka0/FsKafka.fs
@@ -266,6 +266,8 @@ type KafkaConsumerConfig = private { inner: ConsumerConfig; topics: string list;
             ?statisticsInterval,
             /// Consumed offsets commit interval. Default 5s.
             ?autoCommitInterval,
+            /// Override default policy wrt auto-creating topics. Confluent.Kafka < 1.5 default: true; Confluent.Kafka >= 1.5 default: false
+            ?allowAutoCreateTopics,
             /// Misc configuration parameters to be passed to the underlying CK consumer. Same as constructor argument for Confluent.Kafka >=1.2.
             ?config : IDictionary<string,string>,
             /// Misc configuration parameter to be passed to the underlying CK consumer.
@@ -298,6 +300,7 @@ type KafkaConsumerConfig = private { inner: ConsumerConfig; topics: string list;
         fetchMinBytes |> Option.iter (fun x -> c.FetchMinBytes <- x) // Fetch waits for this amount of data for up to FetchWaitMaxMs (100)
         autoCommitInterval |> Option.iter<TimeSpan> (fun x -> c.AutoCommitIntervalMs <- Nullable <| int x.TotalMilliseconds)
         statisticsInterval |> Option.iter<TimeSpan> (fun x -> c.StatisticsIntervalMs <- Nullable <| int x.TotalMilliseconds)
+        allowAutoCreateTopics |> Option.iter (fun x -> c.AllowAutoCreateTopics <- Nullable x)
         custom |> Option.iter (fun xs -> for KeyValue (k,v) in xs do c.Set(k,v))
         customize |> Option.iter<ConsumerConfig -> unit> (fun f -> f c)
         {   inner = c


### PR DESCRIPTION
[librdkafka 1.5.0](https://github.com/edenhill/librdkafka/releases/tag/v1.5.0) changes the default value of `allow.auto.create.topics` from `true` to `false`
This exposes a clean way to override the setting

🤔 should it default to `true` if unspecified?