### PR TITLE
Add mechanism to tear down KafkaMonitor threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,13 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- BREAKING: The name of the start function in FsKafka.KafkaMonitor `StartAsChild` was changed to `Start`, changed the return type from to `IDisposable`
+
 ### Removed
 ### Fixed
+
+- Provided the mechanism to tear down the monitoring loop when the consumer stops
 
 <a name="1.5.1"></a>
 ## [1.5.1] - 2020-08-04

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ let cfg = KafkaConsumerConfig.Create("MyClientId", "kafka:9092", ["MyTopic"], "M
 
 async {
     use consumer = BatchedConsumer.Start(log, cfg, handler)
-    do! KafkaMonitor(log).StartAsChild(consumer.Inner, cfg.Inner.GroupId)
+    use _ = KafkaMonitor(log).Start(consumer.Inner, cfg.Inner.GroupId)
     return! consumer.AwaitCompletion()
 } |> Async.RunSynchronously
 ```

--- a/tests/FsKafka.Integration/Integration.fs
+++ b/tests/FsKafka.Integration/Integration.fs
@@ -410,7 +410,7 @@ type T4(testOutputHelper) =
         let! res = async {
             use consumer = BatchedConsumer.Start(log, consumerCfg, handle)
             consumer.StopAfter (TimeSpan.FromSeconds 20.)
-            do! FsKafka.KafkaMonitor(log).StartAsChild(consumer.Inner, consumerCfg.Inner.GroupId)
+            use _ = FsKafka.KafkaMonitor(log).Start(consumer.Inner, consumerCfg.Inner.GroupId)
             return! consumer.AwaitCompletion() |> Async.Catch    
         }
         


### PR DESCRIPTION
This change makes the monitor run disposable so that the thread can be terminated properly.
I was thinking about providing an option to make the loop terminate after x number of fail count, but that PR will follow later as needed.

Resolves #74 