### PR TITLE
Adding exception logging for consumer's batch processing loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ## [Unreleased]
 
 ### Added
+
+- Added a logging for exception caught in the batch processing loop. Any uncaught exception from the handler will be logged here as well.  
+
 ### Changed
 ### Removed
 ### Fixed

--- a/src/FsKafka/FsKafka.fs
+++ b/src/FsKafka/FsKafka.fs
@@ -469,14 +469,15 @@ module private ConsumerImpl =
             let rec loop () = async {
                 if not collection.IsCompleted then
                     let batchWatch = System.Diagnostics.Stopwatch()
-                    let mutable batchLen = 0
+                    let mutable batchLen, batchSize = 0, 0L
                     use __ = Serilog.Context.LogContext.PushProperty("partition", Binding.partitionValue key.Partition)
                     try match nextBatch() with
                         | [||] -> ()
                         | batch ->
                             batchLen <- batch.Length
+                            batchSize <- batch |> Array.sumBy approximateMessageBytes
                             batchWatch.Start()
-                            log.Debug("Dispatching {count} message(s) to handler", batchLen)
+                            log.ForContext("batchSize", batchSize).Debug("Dispatching {batchLen} message(s) to handler", batchLen)
                             // run the handler function
                             do! handler batch
 
@@ -485,10 +486,9 @@ module private ConsumerImpl =
                             consumer.StoreOffset(lastItem)
 
                             // decrement in-flight message counter
-                            let batchSize = batch |> Array.sumBy approximateMessageBytes
                             counter.Delta(-batchSize)
                     with e ->
-                        log.ForContext("batchSize", batchLen).ForContext("handlerDuration", batchWatch.Elapsed)
+                        log.ForContext("batchSize", batchSize).ForContext("batchLen", batchLen).ForContext("handlerDuration", batchWatch.Elapsed)
                             .Information(e, "Exiting batch processing loop due to handler exception") 
                         tcs.TrySetException e |> ignore
                         cts.Cancel()

--- a/src/FsKafka/FsKafka.fs
+++ b/src/FsKafka/FsKafka.fs
@@ -462,18 +462,20 @@ module private ConsumerImpl =
             let buffer = Array.zeroCreate buf.maxBatchSize
             let nextBatch () =
                 let count = collection.FillBuffer(buffer, buf.maxBatchDelay)
-                if count <> 0 then log.Debug("Consuming {count}", count)
                 let batch = Array.init count (fun i -> buffer.[i])
                 Array.Clear(buffer, 0, count)
                 batch
 
             let rec loop () = async {
                 if not collection.IsCompleted then
+                    let batchWatch = System.Diagnostics.Stopwatch()
+                    let mutable batchLen = 0
+                    use __ = Serilog.Context.LogContext.PushProperty("partition", Binding.partitionValue key.Partition)
                     try match nextBatch() with
                         | [||] -> ()
                         | batch ->
-                            use __ = Serilog.Context.LogContext.PushProperty("partition", Binding.partitionValue key.Partition)
-                            log.Debug("Dispatching {count} message(s) to handler", batch.Length)
+                            batchLen <- batch.Length
+                            batchWatch.Start()
                             // run the handler function
                             do! handler batch
 
@@ -485,7 +487,8 @@ module private ConsumerImpl =
                             let batchSize = batch |> Array.sumBy approximateMessageBytes
                             counter.Delta(-batchSize)
                     with e ->
-                        log.Information("Exception occurred while processing a batch - {exception}: {message}", e.GetType().FullName, e.Message)
+                        log.ForContext("batchSize", batchLen).ForContext("handlerDuration", batchWatch.Elapsed)
+                            .Information(e, "Exiting batch processing loop due to handler exception") 
                         tcs.TrySetException e |> ignore
                         cts.Cancel()
                     return! loop() }

--- a/src/FsKafka/FsKafka.fs
+++ b/src/FsKafka/FsKafka.fs
@@ -476,6 +476,7 @@ module private ConsumerImpl =
                         | batch ->
                             batchLen <- batch.Length
                             batchWatch.Start()
+                            log.Debug("Dispatching {count} message(s) to handler", batchLen)
                             // run the handler function
                             do! handler batch
 

--- a/src/FsKafka/FsKafka.fs
+++ b/src/FsKafka/FsKafka.fs
@@ -485,7 +485,7 @@ module private ConsumerImpl =
                             let batchSize = batch |> Array.sumBy approximateMessageBytes
                             counter.Delta(-batchSize)
                     with e ->
-                        log.Information("Exception occurred while processing a batch: {message}", e.Message)
+                        log.Information("Exception occurred while processing a batch - {exception}: {message}", e.GetType().FullName, e.Message)
                         tcs.TrySetException e |> ignore
                         cts.Cancel()
                     return! loop() }

--- a/src/FsKafka/FsKafka.fs
+++ b/src/FsKafka/FsKafka.fs
@@ -485,6 +485,7 @@ module private ConsumerImpl =
                             let batchSize = batch |> Array.sumBy approximateMessageBytes
                             counter.Delta(-batchSize)
                     with e ->
+                        log.Information("Exception occurred while processing a batch: {message}", e.Message)
                         tcs.TrySetException e |> ignore
                         cts.Cancel()
                     return! loop() }

--- a/src/FsKafka0/FsKafka.fs
+++ b/src/FsKafka0/FsKafka.fs
@@ -488,7 +488,7 @@ module private ConsumerImpl =
                         | batch ->
                             batchLen <- batch.Length
                             batchWatch.Start()
-                            log.Debug("Dispatching {count} message(s) to handler", batch.Length)
+                            log.Debug("Dispatching {count} message(s) to handler", batchLen)
                             // run the handler function
                             do! handler batch
 


### PR DESCRIPTION
Although any uncaught exception within the consumer's batch processing loop will bubble up to the client, it is helpful to log the exception in case the client does not properly handle/log it. 
FsKafka simply logs the fully qualified name of the exception along with the exception message, but the full stacktrace and such needs to be logged from the client side.