### PR TITLE
Fix memory leak in tail recursion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Removed
 ### Fixed
 
+- Memory leak in the tail recursion: disposables within the tail recursion loop do not get disposed until the recursion terminates. Fixed it by replacing the tail recursion with while loop.
+
 <a name="1.5.3"></a>
 ## [1.5.3] - 2020-09-08
 

--- a/src/FsKafka0/FsKafka.fs
+++ b/src/FsKafka0/FsKafka.fs
@@ -478,34 +478,36 @@ module private ConsumerImpl =
                 Array.Clear(buffer, 0, count)
                 batch
 
-            let rec loop () = async {
-                if not collection.IsCompleted then
-                    let batchWatch = System.Diagnostics.Stopwatch()
-                    let mutable batchLen, batchSize = 0, 0L
-                    use __ = Serilog.Context.LogContext.PushProperty("partition", Binding.partitionValue key.Partition)
-                    try match nextBatch() with
-                        | [||] -> ()
-                        | batch ->
-                            batchLen <- batch.Length
-                            batchSize <- batch |> Array.sumBy (fun m -> getMessageSize m)
-                            batchWatch.Start()
-                            log.ForContext("batchSize", batchSize).Debug("Dispatching {batchLen} message(s) to handler", batchLen)
-                            // run the handler function
-                            do! handler batch
+            let processBatch = async {
+                let batchWatch = System.Diagnostics.Stopwatch()
+                let mutable batchLen, batchSize = 0, 0L
+                try match nextBatch() with
+                    | [||] -> ()
+                    | batch ->
+                        batchLen <- batch.Length
+                        batchSize <- batch |> Array.sumBy (fun m -> getMessageSize m)
+                        batchWatch.Start()
+                        log.ForContext("batchSize", batchSize).Debug("Dispatching {batchLen} message(s) to handler", batchLen)
+                        // run the handler function
+                        do! handler batch
 
-                            // store completed offsets
-                            storeOffset consumer (getBatchOffset batch)
+                        // store completed offsets
+                        storeOffset consumer (getBatchOffset batch)
 
-                            // decrement in-flight message counter
-                            counter.Delta -batchSize
-                    with e ->
-                        log.ForContext("batchSize", batchSize).ForContext("batchLen", batchLen).ForContext("handlerDuration", batchWatch.Elapsed)
-                            .Information(e, "Exiting batch processing loop due to handler exception")
-                        tcs.TrySetException e |> ignore
-                        cts.Cancel()
-                    return! loop() }
+                        // decrement in-flight message counter
+                        counter.Delta -batchSize
+                with e ->
+                    log.ForContext("batchSize", batchSize).ForContext("batchLen", batchLen).ForContext("handlerDuration", batchWatch.Elapsed)
+                        .Information(e, "Exiting batch processing loop due to handler exception")
+                    tcs.TrySetException e |> ignore
+                    cts.Cancel() }
+            
+            let loop = async {
+                use __ = Serilog.Context.LogContext.PushProperty("partition", Binding.partitionValue key.Partition)
+                while not collection.IsCompleted do
+                    do! processBatch }
 
-            Async.Start(loop(), cts.Token)
+            Async.Start(loop, cts.Token)
 
         use _ = partitionedCollection.OnPartitionAdded.Subscribe consumePartition
         use _ = consumer.OnPartitionsRevoked.Subscribe (fun ps -> for p in ps do partitionedCollection.Revoke p)


### PR DESCRIPTION
There was a memory leak in the tail recursion loop `rec loop` where disposables are not being disposed until the recursion terminates. The fix was done to replace the recursion with while loop.

To illustrate the issue, here is an example for memory leak in tail recursion:

```
let myDisposer name =
        { new System.IDisposable
          with member this.Dispose() = printfn "disposing %s" name }
    let mutable count = 3
    let rec loop () = async {
        if count > 0 then
            use _ = myDisposer "foo"
            count <- count - 1
            printfn "sleeping for 2 sec for count %d" count
            do! Async.Sleep(2000)
            return! loop()
    }
    loop() |> Async.RunSynchronously
```

In this case, disposable will not be disposed until the tail recursion terminates. Thus the outcome will be:
```
sleeping for 2 sec for count 3
sleeping for 2 sec for count 2
sleeping for 2 sec for count 1
disposing foo
disposing foo
disposing foo
```

The fix was placed to replace the recursion with while loop:
```
let myDisposer name =
        { new System.IDisposable
          with member this.Dispose() = printfn "disposing %s" name }
    let mutable count = 3
    let aux = async {
        count <- count - 1
        printfn "sleeping for 2 sec for count %d" count
        do! Async.Sleep(2000)
    }
    let loop = async {
        use _ = myDisposer "foo"
        while count > 0 do
            do! aux
    }
    loop |> Async.RunSynchronously
```

In this case, you will only have one disposable that gets disposed when the while loop terminates:
```
sleeping for 2 sec for count 3
sleeping for 2 sec for count 2
sleeping for 2 sec for count 1
disposing foo
```
