### PR TITLE
Target Confluent.Kafka / librdkafka 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 ### Changed
 
-- Target [`Confluent.Kafka [1.5.2]`](https://github.com/confluentinc/confluent-kafka-dotnet/releases/tag/v1.5.2), [`librdkafka.redist [1.5.2]`](https://github.com/edenhill/librdkafka/releases/tag/v1.5.2)
+- Target [`Confluent.Kafka [1.5.2]`](https://github.com/confluentinc/confluent-kafka-dotnet/blob/v1.5.2/CHANGELOG.md#152), [`librdkafka.redist [1.5.2]`](https://github.com/edenhill/librdkafka/releases/tag/v1.5.2)
 
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+
+- Target [`Confluent.Kafka [1.5.2]`](https://github.com/confluentinc/confluent-kafka-dotnet/releases/tag/v1.5.2), [`librdkafka.redist [1.5.2]`](https://github.com/edenhill/librdkafka/releases/tag/v1.5.2)
+
 ### Removed
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 ### Changed
 
-- Target [`Confluent.Kafka [1.5.2]`](https://github.com/confluentinc/confluent-kafka-dotnet/blob/v1.5.2/CHANGELOG.md#152), [`librdkafka.redist [1.5.2]`](https://github.com/edenhill/librdkafka/releases/tag/v1.5.2)
+- Target [`Confluent.Kafka [1.5.2]`](https://github.com/confluentinc/confluent-kafka-dotnet/blob/v1.5.2/CHANGELOG.md#152), [`librdkafka.redist [1.5.2]`](https://github.com/edenhill/librdkafka/releases/tag/v1.5.2) [#80](https://github.com/jet/FsKafka/pull/80)
 
 ### Removed
 ### Fixed

--- a/src/FsKafka/FsKafka.fsproj
+++ b/src/FsKafka/FsKafka.fsproj
@@ -23,8 +23,8 @@
     <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' != 'net461' " />
 
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Confluent.Kafka" Version="[1.5.0]" />
-    <PackageReference Include="librdkafka.redist" Version="[1.5.0]" />
+    <PackageReference Include="Confluent.Kafka" Version="[1.5.2]" />
+    <PackageReference Include="librdkafka.redist" Version="[1.5.2]" />
     <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>
 


### PR DESCRIPTION
No breaking changes, Just pinning a dependency on 1.5.2, which brings various bugfixes