### PR TITLE
Add AwaitWithStopOnCancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,12 @@ The `Unreleased` section name is replaced by the expected version of next releas
 ### Added
 
 - Added overload of `InFlightMessageCounter.AwaitThreshold` with `busyWork` argument [#73](https://github.com/jet/FsKafka/pull/73)
+- `BatchedConsumer`: Added `AwaitWithStopOnCancellation` [#83](https://github.com/jet/FsKafka/pull/83)
 
 ### Changed
+
+- `BatchedConsumer`: Renamed `AwaitCompletion` to `AwaitShutdown` [#83](https://github.com/jet/FsKafka/pull/83)
+
 ### Removed
 
 - Removed deprecated overload of `KafkaProducerConfig.Create` introduced in 1.5.0 [#73](https://github.com/jet/FsKafka/pull/73)

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ let cfg = KafkaConsumerConfig.Create("MyClientId", "kafka:9092", ["MyTopic"], "M
 
 async {
     use consumer = BatchedConsumer.Start(log, cfg, handler)
-    return! consumer.AwaitCompletion()
+    return! consumer.AwaitShutdown()
 } |> Async.RunSynchronously
 ```
 
@@ -142,6 +142,6 @@ let cfg = KafkaConsumerConfig.Create("MyClientId", "kafka:9092", ["MyTopic"], "M
 async {
     use consumer = BatchedConsumer.Start(log, cfg, handler)
     use _ = KafkaMonitor(log).Start(consumer.Inner, cfg.Inner.GroupId)
-    return! consumer.AwaitCompletion()
+    return! consumer.AwaitShutdown()
 } |> Async.RunSynchronously
 ```

--- a/src/FsKafka/FsKafka.fs
+++ b/src/FsKafka/FsKafka.fs
@@ -479,7 +479,7 @@ module private ConsumerImpl =
 
 /// Creates and wraps a Confluent.Kafka IConsumer, wrapping it to afford a batched consumption mode with implicit offset progression at the end of each
 /// (parallel across partitions, sequenced/monotonic within) batch of processing carried out by the `partitionHandler`
-/// Conclusion of the processing (when a `partitionHandler` throws and/or `Stop()` is called) can be awaited via `AwaitShutdown()`
+/// Conclusion of the processing (when a `partitionHandler` throws and/or `Stop()` is called) can be awaited via <c>AwaitShutdown</c> or <c>AwaitWithStopOnCancellation</c>.
 type BatchedConsumer private (inner : IConsumer<string, string>, task : Task<unit>, triggerStop) =
     member __.Inner = inner
 
@@ -489,10 +489,18 @@ type BatchedConsumer private (inner : IConsumer<string, string>, task : Task<uni
     /// Inspects current status of processing task
     member __.Status = task.Status
     member __.RanToCompletion = task.Status = TaskStatus.RanToCompletion
-    /// Asynchronously awaits until consumer stops or is faulted
+    /// Asynchronously awaits until consume loop stops or is faulted. <br/>
+    /// NOTE: does not Stop the consumer in response to Cancellation; see <c>AwaitWithStopOnCancellation</c> for such a mechanism
     member __.AwaitShutdown() =
-        // NOTE NOT Async.AwaitTask task, or we hang in the case of termination via `Stop()`
+        // NOTE NOT Async.AwaitTask task, or we'd hang in the case of Cancellation via `Stop()`
         Async.AwaitTaskCorrect task
+    /// Asynchronously awaits until this consumer stops or is faulted.<br/>
+    /// Reacts to cancellation by Stopping the Consume loop cia <c>Stop()</c>; see <c>AwaitShutdown</c> if such semantics are not desired.
+    member consumer.AwaitWithStopOnCancellation() = async {
+        let! ct = Async.CancellationToken
+        use _ = ct.Register(fun () -> consumer.Stop())
+        return! consumer.AwaitShutdown()
+    }
 
     /// Starts a Kafka consumer with the provided configuration. Batches are grouped by topic partition.
     /// Batches belonging to the same topic partition will be scheduled sequentially and monotonically; however batches from different partitions can run concurrently.

--- a/src/FsKafka0/FsKafka.fs
+++ b/src/FsKafka0/FsKafka.fs
@@ -481,7 +481,7 @@ module private ConsumerImpl =
 
 /// Creates and wraps a Confluent.Kafka IConsumer, wrapping it to afford a batched consumption mode with implicit offset progression at the end of each
 /// (parallel across partitions, sequenced/monotonic within) batch of processing carried out by the `partitionHandler`
-/// Conclusion of the processing (when a `partitionHandler` throws and/or `Stop()` is called) can be awaited via `AwaitCompletion()`
+/// Conclusion of the processing (when a `partitionHandler` throws and/or `Stop()` is called) can be awaited via `AwaitShutdown()`
 type BatchedConsumer private (inner : Consumer<string, string>, task : Task<unit>, triggerStop) =
     member __.Inner = inner
 
@@ -492,7 +492,9 @@ type BatchedConsumer private (inner : Consumer<string, string>, task : Task<unit
     member __.Status = task.Status
     member __.RanToCompletion = task.Status = System.Threading.Tasks.TaskStatus.RanToCompletion
     /// Asynchronously awaits until consumer stops or is faulted
-    member __.AwaitCompletion() = Async.AwaitTaskCorrect task
+    member __.AwaitShutdown() =
+        // NOTE NOT Async.AwaitTask task, or we hang in the case of termination via `Stop()`
+        Async.AwaitTaskCorrect task
 
     /// Starts a Kafka consumer with the provided configuration. Batches are grouped by topic partition.
     /// Batches belonging to the same topic partition will be scheduled sequentially and monotonically; however batches from different partitions can run concurrently.

--- a/src/FsKafka0/FsKafka.fs
+++ b/src/FsKafka0/FsKafka.fs
@@ -481,7 +481,7 @@ module private ConsumerImpl =
 
 /// Creates and wraps a Confluent.Kafka IConsumer, wrapping it to afford a batched consumption mode with implicit offset progression at the end of each
 /// (parallel across partitions, sequenced/monotonic within) batch of processing carried out by the `partitionHandler`
-/// Conclusion of the processing (when a `partitionHandler` throws and/or `Stop()` is called) can be awaited via `AwaitShutdown()`
+/// Conclusion of the processing (when a `partitionHandler` throws and/or `Stop()` is called) can be awaited via <c>AwaitShutdown</c> or <c>AwaitWithStopOnCancellation</c>.
 type BatchedConsumer private (inner : Consumer<string, string>, task : Task<unit>, triggerStop) =
     member __.Inner = inner
 
@@ -491,10 +491,18 @@ type BatchedConsumer private (inner : Consumer<string, string>, task : Task<unit
     /// Inspects current status of processing task
     member __.Status = task.Status
     member __.RanToCompletion = task.Status = System.Threading.Tasks.TaskStatus.RanToCompletion
-    /// Asynchronously awaits until consumer stops or is faulted
+    /// Asynchronously awaits until consume loop stops or is faulted.<br/>
+    /// NOTE: does not Stop the consumer in response to Cancellation; see <c>AwaitWithStopOnCancellation</c> for such a mechanism
     member __.AwaitShutdown() =
-        // NOTE NOT Async.AwaitTask task, or we hang in the case of termination via `Stop()`
+        // NOTE NOT Async.AwaitTask task, or we'd hang in the case of Cancellation via `Stop()`
         Async.AwaitTaskCorrect task
+    /// Asynchronously awaits until this consumer stops or is faulted.<br/>
+    /// Reacts to cancellation by Stopping the Consume loop cia <c>Stop()</c>; see <c>AwaitShutdown</c> if such semantics are not desired.
+    member consumer.AwaitWithStopOnCancellation() = async {
+        let! ct = Async.CancellationToken
+        use _ = ct.Register(fun () -> consumer.Stop())
+        return! consumer.AwaitShutdown()
+    }
 
     /// Starts a Kafka consumer with the provided configuration. Batches are grouped by topic partition.
     /// Batches belonging to the same topic partition will be scheduled sequentially and monotonically; however batches from different partitions can run concurrently.

--- a/tests/FsKafka.Integration/Integration.fs
+++ b/tests/FsKafka.Integration/Integration.fs
@@ -113,7 +113,7 @@ module Helpers =
 
             timeout |> Option.iter consumer.StopAfter
 
-            return! consumer.AwaitCompletion()
+            return! consumer.AwaitShutdown()
         }
 
         return! Async.Parallel [for i in 1 .. numConsumers -> mkConsumer i] |> Async.Ignore
@@ -390,7 +390,7 @@ type T4(testOutputHelper) =
         let! res = async {
             use consumer = BatchedConsumer.Start(log, consumerCfg, handle)
             consumer.StopAfter (TimeSpan.FromSeconds 20.)
-            return! consumer.AwaitCompletion() |> Async.Catch    
+            return! consumer.AwaitShutdown() |> Async.Catch
         }
         
         test <@ match res with Choice2Of2 e when e.Message = "Completed" -> true | _ -> false @>
@@ -411,7 +411,7 @@ type T4(testOutputHelper) =
             use consumer = BatchedConsumer.Start(log, consumerCfg, handle)
             consumer.StopAfter (TimeSpan.FromSeconds 20.)
             use _ = FsKafka.KafkaMonitor(log).Start(consumer.Inner, consumerCfg.Inner.GroupId)
-            return! consumer.AwaitCompletion() |> Async.Catch    
+            return! consumer.AwaitShutdown() |> Async.Catch
         }
         
         test <@ match res with Choice2Of2 e when e.Message = "Completed" -> true | _ -> false @>


### PR DESCRIPTION
The current API does not provide a clear way to have a service cleanly shut down in response to the faulting of one of a set of consumers.

This PR extends the API to provide such a mechanism