### PR TITLE
Add ProducerConfig maxMessageBytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 - Added overload of `InFlightMessageCounter.AwaitThreshold` with `busyWork` argument [#73](https://github.com/jet/FsKafka/pull/73)
 - `BatchedConsumer`: Added `AwaitWithStopOnCancellation` [#83](https://github.com/jet/FsKafka/pull/83)
+- `ProducerConfig`: Add `maxMessageBytes` parameter to constructor [#84](https://github.com/jet/FsKafka/pull/84)
 
 ### Changed
 

--- a/src/FsKafka/FsKafka.fs
+++ b/src/FsKafka/FsKafka.fs
@@ -252,9 +252,9 @@ type KafkaConsumerConfig = private { inner: ConsumerConfig; topics: string list;
             /// Misc configuration parameters to be passed to the underlying CK consumer. Same as constructor argument for Confluent.Kafka >=1.2.
             ?config : IDictionary<string,string>,
             /// Misc configuration parameter to be passed to the underlying CK consumer.
-            ?custom,
+            ?custom : #seq<KeyValuePair<string, string>>,
             /// Postprocesses the ConsumerConfig after the rest of the rules have been applied
-            ?customize,
+            ?customize : ConsumerConfig -> unit,
 
             (* Client-side batching / limiting of reading ahead to constrain memory consumption *)
 
@@ -284,7 +284,7 @@ type KafkaConsumerConfig = private { inner: ConsumerConfig; topics: string list;
         statisticsInterval |> Option.iter<TimeSpan> (fun x -> c.StatisticsIntervalMs <- Nullable <| int x.TotalMilliseconds)
         allowAutoCreateTopics |> Option.iter (fun x -> c.AllowAutoCreateTopics <- Nullable x)
         custom |> Option.iter (fun xs -> for KeyValue (k,v) in xs do c.Set(k,v))
-        customize |> Option.iter<ConsumerConfig -> unit> (fun f -> f c)
+        customize |> Option.iter (fun f -> f c)
         {   inner = c
             topics = match Seq.toList topics with [] -> invalidArg "topics" "must be non-empty collection" | ts -> ts
             buffering = {

--- a/src/FsKafka0/FsKafka.fs
+++ b/src/FsKafka0/FsKafka.fs
@@ -65,9 +65,9 @@ type KafkaProducerConfig private (inner, bootstrapServers : string) =
             /// Miscellaneous configuration parameters to be passed to the underlying Confluent.Kafka producer configuration. Same as constructor argument for Confluent.Kafka >=1.2.
             ?config : IDictionary<string,string>,
             /// Miscellaneous configuration parameters to be passed to the underlying Confluent.Kafka producer configuration.
-            ?custom,
+            ?custom : #seq<KeyValuePair<string, string>>,
             /// Postprocesses the ProducerConfig after the rest of the rules have been applied
-            ?customize) =
+            ?customize : ProducerConfig -> unit) =
         let linger, maxInFlight =
             match batching with
             | Linger l -> l, None

--- a/src/FsKafka0/FsKafka.fs
+++ b/src/FsKafka0/FsKafka.fs
@@ -231,9 +231,9 @@ type KafkaConsumerConfig = private { inner: ConsumerConfig; topics: string list;
             /// Misc configuration parameters to be passed to the underlying CK consumer. Same as constructor argument for Confluent.Kafka >=1.2.
             ?config : IDictionary<string,string>,
             /// Misc configuration parameter to be passed to the underlying CK consumer.
-            ?custom,
+            ?custom : #seq<KeyValuePair<string, string>>,
             /// Postprocesses the ConsumerConfig after the rest of the rules have been applied
-            ?customize,
+            ?customize : ConsumerConfig -> unit,
 
             (* Client-side batching / limiting of reading ahead to constrain memory consumption *)
 
@@ -262,7 +262,7 @@ type KafkaConsumerConfig = private { inner: ConsumerConfig; topics: string list;
         statisticsInterval |> Option.iter<TimeSpan> (fun x -> c.StatisticsIntervalMs <- Nullable <| int x.TotalMilliseconds)
         allowAutoCreateTopics |> Option.iter (fun x -> c.AllowAutoCreateTopics <- Nullable x)
         custom |> Option.iter (fun xs -> for KeyValue (k,v) in xs do c.Set(k,v))
-        customize |> Option.iter<ConsumerConfig -> unit> (fun f -> f c)
+        customize |> Option.iter (fun f -> f c)
         {   inner = c
             topics = match Seq.toList topics with [] -> invalidArg "topics" "must be non-empty collection" | ts -> ts
             buffering = {


### PR DESCRIPTION
- Add type annotations to custom config helpers
- Expose `maxMessageBytes` on the `ProducerConfig` directly