### PR TITLE
Remove targeting for Net 461

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,4 @@
     <NoWarn>$(NoWarn);FS2003;NU5105</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup> <!-- net461 ref assemblies https://stackoverflow.com/a/57384175/11635 -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The [templates](#templates) are the best way to see how to consume it; these ins
 
 NB The tests are reliant on a `TEST_KAFKA_BROKER` environment variable pointing to a Broker that has been configured to auto-create ephemeral Kafka Topics as required by the tests (each test run writes to a guid-named topic)
 
-### build, including tests on netcoreapp2.1
+### build, including tests on netcoreapp3.1
 
 ```powershell
 export TEST_KAFKA_BROKER="<server>:9092"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ F# friendly wrapper for `Confluent.Kafka`, with minimal dependencies or addition
 
 ## Usage
 
-FsKafka is delivered as a [Nuget package](https://www.nuget.org/packages/FsKafka/) targeting `netstandard2.0` (F# 4.5+) profiles.
+FsKafka is delivered as a [Nuget package](https://www.nuget.org/packages/FsKafka/) targeting `netstandard2.0` and F# >= 4.5.
 
 ```powershell
 Install-Package FsKafka

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The [templates](#templates) are the best way to see how to consume it; these ins
 
 NB The tests are reliant on a `TEST_KAFKA_BROKER` environment variable pointing to a Broker that has been configured to auto-create ephemeral Kafka Topics as required by the tests (each test run writes to a guid-named topic)
 
-### build, including tests on net461 and netcoreapp2.1
+### build, including tests on netcoreapp2.1
 
 ```powershell
 export TEST_KAFKA_BROKER="<server>:9092"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ F# friendly wrapper for `Confluent.Kafka`, with minimal dependencies or addition
 
 ## Usage
 
-FsKafka is delivered as a multi-targeted [Nuget package](https://www.nuget.org/packages/FsKafka/) targeting `net461` (F# 3.1+) and `netstandard2.0` (F# 4.5+) profiles.
+FsKafka is delivered as a [Nuget package](https://www.nuget.org/packages/FsKafka/) targeting `netstandard2.0` (F# 4.5+) profiles.
 
 ```powershell
 Install-Package FsKafka

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 name: $(Rev:r)
 
 # Summary:
-#	Linux: Tests using docker Kafka instance (note test suite does not run net461 as CK on mono is not supported)
+#	Linux: Tests using docker Kafka instance (note test suite does not run net framework as CK on mono is not supported)
 #	Windows: Builds and emits nupkg as artifacts
 #	MacOS: Builds only 
 

--- a/src/FsKafka/FsKafka.fsproj
+++ b/src/FsKafka/FsKafka.fsproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <WarningLevel>5</WarningLevel>
     <IsTestProject>false</IsTestProject>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
-    <DefineConstants Condition=" '$(TargetFramework)' == 'net461' ">NET461</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,8 +18,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.2.0" PrivateAssets="All" />
 
-    <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net461' " />
-    <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' != 'net461' " />
+    <PackageReference Include="FSharp.Core" Version="4.3.4" />
 
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Confluent.Kafka" Version="[1.6.2]" />

--- a/tests/FsKafka.Integration/FsKafka.Integration.fsproj
+++ b/tests/FsKafka.Integration/FsKafka.Integration.fsproj
@@ -1,9 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
-    <!-- Confluent don't support Mono OOTB https://github.com/confluentinc/confluent-kafka-dotnet/issues/400 -->
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <WarningLevel>5</WarningLevel>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/FsKafka.Integration/FsKafka.Integration.fsproj
+++ b/tests/FsKafka.Integration/FsKafka.Integration.fsproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="5.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Destructurama.FSharp.NetCore" Version="1.0.14" />
     <PackageReference Include="unquote" Version="4.0" />

--- a/tests/FsKafka.Integration/Integration.fs
+++ b/tests/FsKafka.Integration/Integration.fs
@@ -65,7 +65,7 @@ module Helpers =
     type BatchedConsumer with
         member c.StopAfter(delay : TimeSpan) =
             async { 
-                do! Async.Sleep delay
+                do! Async.Sleep (int delay.TotalMilliseconds)
                 do c.Stop() 
             } |> Async.Start
 

--- a/tests/FsKafka.Integration/Integration.fs
+++ b/tests/FsKafka.Integration/Integration.fs
@@ -64,7 +64,10 @@ module Helpers =
 
     type BatchedConsumer with
         member c.StopAfter(delay : TimeSpan) =
-            Task.Delay(delay).ContinueWith(fun (_:Task) -> c.Stop()) |> ignore
+            async { 
+                do! Async.Sleep delay
+                do c.Stop() 
+            } |> Async.Start
 
     type TestMessage = { producerId : int ; messageId : int }
 


### PR DESCRIPTION
This should simplify future releases/tests having to support only netstandard 2.0, and simplify upgrading to future versions of Confluent Kafka.
