### PR TITLE
Finish up roadmap to 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
-- Target `Confluent.Kafka [1.7.0]`, `librdkafka.redist [1.7.0]`
+- Target `Confluent.Kafka [1.7.0]`, `librdkafka.redist [1.7.0]` [#89](https://github.com/jet/FsKafka/pull/89)
 ### Removed
 
 - Remove FsKafka0, the older, less loved shimmed version which now be subject to the [scream test](http://www.v-wiki.net/the-scream-test/) with [#87](https://github.com/jet/FsKafka/pull/87)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,12 @@ The `Unreleased` section name is replaced by the expected version of next releas
 
 ### Added
 ### Changed
+- Target `Confluent.Kafka [1.7.0]`, `librdkafka.redist [1.7.0]`
 ### Removed
 
 - Remove FsKafka0, the older, less loved shimmed version which now be subject to the [scream test](http://www.v-wiki.net/the-scream-test/) with [#87](https://github.com/jet/FsKafka/pull/87)
 - Remove targeting for `net461` - support only `netstandard 2.0` with [#88](https://github.com/jet/FsKafka/pull/88)
+- Remove `AwaitThreshold` in `InFlightMessageCounter` [#89](https://github.com/jet/FsKafka/pull/89)
 
 ### Fixed
 

--- a/src/FsKafka/FsKafka.fs
+++ b/src/FsKafka/FsKafka.fs
@@ -499,7 +499,7 @@ module private ConsumerImpl =
         // run the consumer
         let ct = cts.Token
         try while not ct.IsCancellationRequested do
-                counter.AwaitThreshold(ct, consumer, ?busyWork=None)
+                counter.AwaitThreshold(ct, consumer)
                 try let result = consumer.Consume(ct) // NB TimeSpan overload yields AVEs on 1.0.0-beta2
                     if result <> null then
                         counter.Delta(+approximateMessageBytes result)

--- a/src/FsKafka/FsKafka.fs
+++ b/src/FsKafka/FsKafka.fs
@@ -254,10 +254,6 @@ module Core =
                 while Volatile.Read(&inFlightBytes) > minInFlightBytes && not ct.IsCancellationRequested do
                     showConsumerWeAreStillAlive ()
                 log.Information "Consumer resuming polling"
-        [<Obsolete "Please use overload with ?busyWork=None">]
-        // TODO remove ?busyWork=None in internal call when removing this overload
-        member this.AwaitThreshold(ct : CancellationToken, consumer : IConsumer<_,_>) =
-           this.AwaitThreshold(ct, consumer, ?busyWork=None)
 
 /// See https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md for documentation on the implications of specific settings
 [<NoComparison>]

--- a/src/FsKafka/FsKafka.fsproj
+++ b/src/FsKafka/FsKafka.fsproj
@@ -15,14 +15,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="librdkafka.redist" Version="[1.7.0]" />
+    <PackageReference Include="Confluent.Kafka" Version="[1.7.0]" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.2.0" PrivateAssets="All" />
 
     <PackageReference Include="FSharp.Core" Version="4.3.4" />
 
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Confluent.Kafka" Version="[1.6.2]" />
-    <PackageReference Include="librdkafka.redist" Version="[1.6.1]" />
     <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>
 

--- a/src/FsKafka/FsKafka.fsproj
+++ b/src/FsKafka/FsKafka.fsproj
@@ -15,14 +15,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="librdkafka.redist" Version="[1.7.0]" />
-    <PackageReference Include="Confluent.Kafka" Version="[1.7.0]" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.2.0" PrivateAssets="All" />
 
     <PackageReference Include="FSharp.Core" Version="4.3.4" />
 
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="librdkafka.redist" Version="[1.7.0]" />
+    <PackageReference Include="Confluent.Kafka" Version="[1.7.0]" />
     <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>
 

--- a/src/FsKafka/FsKafka.fsproj
+++ b/src/FsKafka/FsKafka.fsproj
@@ -21,8 +21,8 @@
     <PackageReference Include="FSharp.Core" Version="4.3.4" />
 
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="librdkafka.redist" Version="[1.7.0]" />
     <PackageReference Include="Confluent.Kafka" Version="[1.7.0]" />
+    <PackageReference Include="librdkafka.redist" Version="[1.7.0]" />
     <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>
 


### PR DESCRIPTION
- Remove `AwaitThreshold`
- Target CK 1.7.0 and librdkafka 1.7.0 