### PR TITLE
Sync AwaitTaskCorrect with canonical version

### DIFF
--- a/src/FsKafka/Infrastructure.fs
+++ b/src/FsKafka/Infrastructure.fs
@@ -1,31 +1,48 @@
 namespace FsKafka
 
-open System
 open System.Threading.Tasks
 
 [<AutoOpen>]
 module private AsyncHelpers =
-    type Async with
-        static member AwaitTaskCorrect (task : Task<'T>) : Async<'T> =
-            Async.FromContinuations <| fun (k,ek,_) ->
-                task.ContinueWith (fun (t:Task<'T>) ->
-                    if t.IsFaulted then
-                        let e = t.Exception
-                        if e.InnerExceptions.Count = 1 then ek e.InnerExceptions.[0]
-                        else ek e
-                    elif t.IsCanceled then ek (TaskCanceledException("Task wrapped with Async has been cancelled."))
-                    elif t.IsCompleted then k t.Result
-                    else ek(Exception "invalid Task state!"))
-                |> ignore
 
-        static member AwaitTaskCorrect (task : Task) : Async<unit> =
-            Async.FromContinuations <| fun (k,ek,_) ->
-                task.ContinueWith (fun (t:Task) ->
+    // Direct copy of canonical implementation at http://www.fssnip.net/7Rc/title/AsyncAwaitTaskCorrect
+    // pending that being officially packaged somewhere or integrated into FSharp.Core https://github.com/fsharp/fslang-suggestions/issues/840
+    type Async with
+
+        /// <summary>
+        ///     Gets the result of given task so that in the event of exception
+        ///     the actual user exception is raised as opposed to being wrapped
+        ///     in a System.AggregateException.
+        /// </summary>
+        /// <param name="task">Task to be awaited.</param>
+        [<System.Diagnostics.DebuggerStepThrough>]
+        static member AwaitTaskCorrect(task : Task<'T>) : Async<'T> =
+            Async.FromContinuations(fun (sc, ec, _cc) ->
+                task.ContinueWith(fun (t : Task<'T>) ->
                     if t.IsFaulted then
                         let e = t.Exception
-                        if e.InnerExceptions.Count = 1 then ek e.InnerExceptions.[0]
-                        else ek e
-                    elif t.IsCanceled then ek (TaskCanceledException("Task wrapped with Async has been cancelled."))
-                    elif t.IsCompleted then k ()
-                    else ek(Exception "invalid Task state!"))
-                |> ignore
+                        if e.InnerExceptions.Count = 1 then ec e.InnerExceptions.[0]
+                        else ec e
+                    elif t.IsCanceled then ec (TaskCanceledException())
+                    else sc t.Result)
+                |> ignore)
+
+        /// <summary>
+        ///     Gets the result of given task so that in the event of exception
+        ///     the actual user exception is raised as opposed to being wrapped
+        ///     in a System.AggregateException.
+        /// </summary>
+        /// <param name="task">Task to be awaited.</param>
+        [<System.Diagnostics.DebuggerStepThrough>]
+        static member AwaitTaskCorrect(task : Task) : Async<unit> =
+            Async.FromContinuations(fun (sc, ec, _cc) ->
+                task.ContinueWith(fun (task : Task) ->
+                    if task.IsFaulted then
+                        let e = task.Exception
+                        if e.InnerExceptions.Count = 1 then ec e.InnerExceptions.[0]
+                        else ec e
+                    elif task.IsCanceled then
+                        ec (TaskCanceledException())
+                    else
+                        sc ())
+                |> ignore)


### PR DESCRIPTION
While we await https://github.com/fsharp/fslang-suggestions/issues/840, this PR canonicalizes the implementation here to align with the Equinox and [fsssnip edition](http://www.fssnip.net/7Rc/title/AsyncAwaitTaskCorrect) in order to avoid people having to eliminate variation in the implementation from their inquiries when investigating threading issues.